### PR TITLE
Major matches controller overhaul

### DIFF
--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -1,69 +1,20 @@
 class MatchesController < ApplicationController
   def new
-    #I am very sorry for what you are about to witness.
     @user = User.find(params[:user_id])
-    if @user.matches.exists?
-      matches = Match.where(user_id: @user.id)
-      matches.each do |match|
-        match.players.destroy_all
-        match.destroy
-      end
-    end
 
     url = "https://na.api.pvp.net/api/lol/na/v2.2/matchlist/by-summoner/#{@user.riot_id}?beginIndex=0&endIndex=5&api_key=#{ENV["api-key"]}"
     response = HTTParty.get(url)
 
     response["matches"].each do |match|
-      unless Match.exists?(match_id: match["matchId"].to_s)
+      #Checks user's matches to see if the one being created exists. If not, creates it.
+      unless @user.matches.where(match_id: match["matchId"].to_s).exists?
         Match.create(user_id: params[:user_id],
          match_id: match["matchId"].to_s,
-          champion_id: match["champion"],
-           gamemode: match["queue"],
-            lane: match["lane"],
-             season: match["season"])
-        url2 = "https://na.api.pvp.net/api/lol/na/v2.2/match/#{match["matchId"]}?api_key=#{ENV["api-key"]}"
-        response2 = HTTParty.get(url2)
-        thismatch = Match.find_by(match_id: match["matchId"].to_s)
-        champion = Champion.find_by(riot_id: thismatch.champion_id)
-        date = (response2["matchCreation"]/1000).to_s
-        duration = (response2["matchDuration"]/60).floor
-        Match.find_by(match_id: match["matchId"].to_s).update_attributes(:date => Date.strptime(date, '%s'), :duration => "#{duration} minutes", :champion => champion.key)
-        count = 0
-
-        response2["participants"].each do |player|
-
-          champerino = Champion.find_by(riot_id: player["championId"])
-          Player.create(name: response2["participantIdentities"][count]["player"]["summonerName"],
-           riot_id: response2["participantIdentities"][count]["player"]["summonerId"],
-           icon_id: response2["participantIdentities"][count]["player"]["profileIcon"],
-           champion_id: player["championId"], lane: player["timeline"]["lane"],
-           team: player["teamId"], won: player["stats"]["winner"],
-           kills: player["stats"]["kills"], deaths: player["stats"]["deaths"],
-           assists: player["stats"]["assists"],
-           tower_kills: player["stats"]["towerKills"],
-           level: player["stats"]["champLevel"],
-           first_blood: player["stats"]["firstTowerKill"],
-           first_tower: player["stats"]["firstTowerKill"],
-           gold_earned: player["stats"]["goldEarned"],
-           damage_dealt: player["stats"]["totalDamageDealtToChampions"],
-           damage_taken: player["stats"]["totalDamageTaken"],
-           healing_done: player["stats"]["totalHeal"],
-           minions_killed: player["stats"]["minionsKilled"],
-           largest_multikill: player["stats"]["largestMultiKill"],
-           wards_placed: player["stats"]["wardsPlaced"],
-           item_0: player["stats"]["item0"],
-           item_1: player["stats"]["item1"],
-           item_2: player["stats"]["item2"],
-           item_3: player["stats"]["item3"],
-           item_4: player["stats"]["item4"],
-           item_5: player["stats"]["item5"],
-           item_6: player["stats"]["item6"],
-           match_id: thismatch.id,
-           user_id: params[:user_id],
-           champion: champerino.key)
-          count += 1
-        end
-
+         champion_id: match["champion"],
+         champion: Champion.where(riot_id: match["champion"])[0].name,
+         gamemode: match["queue"],
+         lane: match["lane"],
+         season: match["season"])
       end
     end
     redirect_to user_path(@user)
@@ -72,6 +23,51 @@ class MatchesController < ApplicationController
   def show
     @user = User.find(params[:user_id])
     @match = Match.find(params[:id])
+
+    url = "https://na.api.pvp.net/api/lol/na/v2.2/match/#{@match.match_id}?api_key=#{ENV["api-key"]}"
+    response = HTTParty.get(url)
+    date = (response["matchCreation"]/1000).to_s
+    duration = (response["matchDuration"]/60).floor
+    @match.update_attributes(:date => Date.strptime(date, '%s'), :duration => "#{duration} minutes", :champion => @match.champion)
+    count = 0
+
+    response["participants"].each do |player|
+      #Checks if this player in this match exists before creating, thus avoiding recreating every time the page is loaded
+      unless Player.where(riot_id: response["participantIdentities"][count]["player"]["summonerId"], match_id: @match.id).exists?
+        champerino = Champion.find_by(riot_id: player["championId"])
+        Player.create(name: response["participantIdentities"][count]["player"]["summonerName"],
+         riot_id: response["participantIdentities"][count]["player"]["summonerId"],
+         icon_id: response["participantIdentities"][count]["player"]["profileIcon"],
+         champion_id: player["championId"], lane: player["timeline"]["lane"],
+         team: player["teamId"],
+         won: player["stats"]["winner"],
+         kills: player["stats"]["kills"],
+         deaths: player["stats"]["deaths"],
+         assists: player["stats"]["assists"],
+         tower_kills: player["stats"]["towerKills"],
+         level: player["stats"]["champLevel"],
+         first_blood: player["stats"]["firstTowerKill"],
+         first_tower: player["stats"]["firstTowerKill"],
+         gold_earned: player["stats"]["goldEarned"],
+         damage_dealt: player["stats"]["totalDamageDealtToChampions"],
+         damage_taken: player["stats"]["totalDamageTaken"],
+         healing_done: player["stats"]["totalHeal"],
+         minions_killed: player["stats"]["minionsKilled"],
+         largest_multikill: player["stats"]["largestMultiKill"],
+         wards_placed: player["stats"]["wardsPlaced"],
+         item_0: player["stats"]["item0"],
+         item_1: player["stats"]["item1"],
+         item_2: player["stats"]["item2"],
+         item_3: player["stats"]["item3"],
+         item_4: player["stats"]["item4"],
+         item_5: player["stats"]["item5"],
+         item_6: player["stats"]["item6"],
+         match_id: @match.id,
+         user_id: params[:user_id],
+         champion: champerino.key)
+        count += 1
+      end
+    end
     @winners = @match.players.where(won: true).order(:lane)
     @losers = @match.players.where(won: false).order(:lane)
   end

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,26 +1,31 @@
-<h2>Log in</h2>
+<div class="row">
+  <div class="user-form small-12 medium-8 large-6 small-centered columns">
+    <h2>Log in</h2>
 
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true %>
+    <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+      <div class="field">
+        <%= f.label :email %><br />
+        <%= f.email_field :email, autofocus: true %>
+      </div>
+
+      <div class="field">
+        <%= f.label :password %><br />
+        <%= f.password_field :password, autocomplete: "off" %>
+      </div>
+
+      <% if devise_mapping.rememberable? -%>
+        <div class="field">
+          <%= f.check_box :remember_me %>
+          <%= f.label :remember_me %>
+        </div>
+      <% end -%>
+
+      <div class="actions">
+        <%= f.submit "Log in" %>
+        </br>
+      </div>
+    <% end %>
+
+    <%= render "devise/shared/links" %>
   </div>
-
-  <div class="field">
-    <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "off" %>
-  </div>
-
-  <% if devise_mapping.rememberable? -%>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
-    </div>
-  <% end -%>
-
-  <div class="actions">
-    <%= f.submit "Log in" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>


### PR DESCRIPTION
Spread out the sizable chunk of code that handled retrieving match history from the API. Previously upon clicking the button to get recent matches, the system would go through every single match pulled and create all of the data in one sitting. I've refactored it to create a match object with only cursory information and moved the code that handles more detailed info to be executed on the page load for each match. This has decreased load times dramatically when retrieving matches and also allows me to retrieve far more matches per request.